### PR TITLE
CHPY-7003: php-sdk stamps order_source

### DIFF
--- a/src/NimbblApi.php
+++ b/src/NimbblApi.php
@@ -16,6 +16,8 @@ class NimbblApi
 
     const VERSION = '3.6.9';
 
+    const ORDER_SOURCE = 'php-sdk';
+
     /*
      * App info is to store the Plugin/integration
      * information

--- a/src/NimbblOrder.php
+++ b/src/NimbblOrder.php
@@ -52,6 +52,9 @@ class NimbblOrder extends NimbblEntity implements JsonSerializable
             $headers = $nimbblRequest->getRequestHeaders();
             $tokenArr = $nimbblRequest->generateToken();
             $headers['Authorization'] = 'Bearer ' . $tokenArr['token'];
+            // order_source is fixed by the creating SDK (anti-spoof); a caller cannot override it.
+            $attributes['order_source'] = \Nimbbl\Api\NimbblApi::ORDER_SOURCE;
+            $attributes['order_source_version'] = \Nimbbl\Api\NimbblApi::VERSION;
             $requestBody = json_encode($attributes);
             
             NimbblLogger::getInstance()->log("create PREPARED - endpoint: {$endpoint}, fullUrl: {$fullUrl}", 'DEBUG', 'NimbblOrder');


### PR DESCRIPTION
Stamps a SDK-fixed `order_source` (+version) on create-order, overriding any caller value (anti-spoof), via a named constant. Consistent with the e-com plugins. Owner builds/tests/publishes. Part of CHPY-6977 / CHPY-7003.